### PR TITLE
El test unitario esta mal, leer la descripción larga para mas explica…

### DIFF
--- a/exercises/21-The-Beatles/test.py
+++ b/exercises/21-The-Beatles/test.py
@@ -18,7 +18,7 @@ def test_functionSing():
     my_funcNameVar = content.index(my_funcName[0])
     regex = r"def sing\(\):"
     my_print = [s for s in content[2:] if "sing()" in s]
-    my_printVar = content.index(my_print[1])
+    my_printVar = content.index(my_print[0])
     regexPrint = r"sing\(\)"
     assert re.match(regex, content[my_funcNameVar])
     assert re.match(regexPrint, content[my_printVar])


### PR DESCRIPTION
…ción

La linea 21 my_printVar = content.index(my_print[1]) es incorrecto, debe tener por valor 0 en vez de 1, si no jamás pasara el test unitario porque arrojara el mensaje de que la función sing no se esta llamando de buena manera. Se puede probar con la solución al código para comprobar lo que digo.:
def sing():
    for i in range(8):
        if i==4:
            print("whisper words of wisdom, let it be, let it be,")
        else:
            print("let it be,")
    print("there will be an answer, let it be")
sing()