### PR TITLE
typo on the instructions

### DIFF
--- a/exercises/17-Russian-Roulette/README.es.md
+++ b/exercises/17-Russian-Roulette/README.es.md
@@ -15,4 +15,4 @@ gira la cámara del revolver para hacer aleatorio el juego. Nadie sabrá dónde 
 
 ## 💡 Pista:
 
-+ La función necesita devolver `You are dead!` (Estás muerto) o `Keep playing!` (Sigue jugando) dependiendo del resultado. Si la bala está en la misma recámara que la del revolver, entonces fue disparada (You are dead!).
++ La función necesita devolver `You're dead!` (Estás muerto) o `Keep playing!` (Sigue jugando) dependiendo del resultado. Si la bala está en la misma recámara que la del revolver, entonces fue disparada (You are dead!).


### PR DESCRIPTION
The instructions ask for the function to return `You are dead!` but the correct version of this string is `You're dead!`. Otherwise the solution will test incorrect.